### PR TITLE
chore: add automerge renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,17 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true
+    },
+    {
+      "matchUpdateTypes": ["patch"],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
With this PR, dependency update PRs should get automerged if all PR checks pass and either:
- it is a patch version change
- it is a dev dependency and it is a minor or patch version change

Documentation: https://docs.renovatebot.com/key-concepts/automerge/