### PR TITLE
fix: use correct version as package version for helm manifest

### DIFF
--- a/src/datasources/artifacthub/index.ts
+++ b/src/datasources/artifacthub/index.ts
@@ -7,6 +7,20 @@ const BASE_URL = 'https://artifacthub.io/api/v1/packages/helm';
 
 export async function getArtifactPackage(artifactHub: ArtifactHubReference) {
   const response = await fetch(`${BASE_URL}/${artifactHub.owner}/${artifactHub.repo}`);
+  if (!response.ok) {
+    throw new Error('response not ok: ' + response.status);
+  }
+
+  const newVar = await response.json();
+  return changeKeys.camelCase(newVar) as ArtifactHubPackage;
+}
+
+export async function getArtifactPackageVersion(artifactHub: ArtifactHubReference, version: string) {
+  const response = await fetch(`${BASE_URL}/${artifactHub.owner}/${artifactHub.repo}/${version}`);
+  if (!response.ok) {
+    throw new Error('response not ok: ' + response.status);
+  }
+
   const newVar = await response.json();
   return changeKeys.camelCase(newVar) as ArtifactHubPackage;
 }


### PR DESCRIPTION
Determine whether to use the app version or chart version as package version by inspecting the current helm chart and print a warning if neither matches.