### PR TITLE
feat: add command to update the latestVersion of a package

### DIFF
--- a/src/commands/package/bump/index.ts
+++ b/src/commands/package/bump/index.ts
@@ -1,0 +1,36 @@
+import {Command, Flags} from '@oclif/core';
+import path from 'node:path';
+
+import {updateLatestVersion} from '../../../manifest.js';
+import {Paths, packagePaths} from '../../../paths.js';
+
+export default class Bump extends Command {
+  static override readonly description = 'bump package latestVersion';
+  static override readonly examples = ['<%= config.bin %> <%= command.id %>'];
+  static override readonly flags = {
+    // flag with no value (-c, --create-version)
+    'dry-run': Flags.boolean({description: 'do not make any changes'}),
+    // flag with no value (-f, --force)
+    force: Flags.boolean({char: 'f'}),
+    // flag with a value (-n, --name=VALUE)
+    name: Flags.string({char: 'n', description: 'name to print', required: true}),
+    // flag to determine the base folder
+    source: Flags.string({char: 's', default: '.', description: 'packages context'}),
+  };
+
+  private paths!: Paths;
+
+  protected override async init(): Promise<void> {
+    const {flags} = await this.parse(Bump);
+    this.paths = packagePaths(path.join(flags.source, 'packages'));
+  }
+
+  public async run(): Promise<void> {
+    const {flags} = await this.parse(Bump);
+    if (await updateLatestVersion(this.paths.package(flags.name))) {
+      this.log(`latestVersion updated for ${flags.name}`);
+    } else {
+      this.log(`latestVersion update not required for ${flags.name}`);
+    }
+  }
+}

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -32,6 +32,23 @@ async function updateVersionsFile(paths: PackagePaths, version: string) {
   await write(paths.versionsYaml(), YAML.stringify(packageVersions));
 }
 
+export async function updateLatestVersion(paths: PackagePaths): Promise<boolean> {
+  const packageVersions = await getPackageVersions(paths);
+  if (packageVersions.versions.length > 0) {
+    const maxVersion = packageVersions.versions
+      .map(it => new SemVer(it.version))
+      .sort((a, b) => a.compare(b) || a.compareBuild(b))[packageVersions.versions.length - 1];
+    const currentLatestVersion = new SemVer(packageVersions.latestVersion);
+    if ((maxVersion.compare(currentLatestVersion) || maxVersion.compareBuild(currentLatestVersion)) > 0) {
+      packageVersions.latestVersion = maxVersion.raw;
+      await write(paths.versionsYaml(), YAML.stringify(packageVersions));
+      return true;
+    }
+  }
+
+  return false;
+}
+
 export async function getLatestVersion(paths: PackagePaths) {
   const packageVersions = await getPackageVersions(paths);
   return new SemVer(packageVersions.latestVersion);


### PR DESCRIPTION
`scout package:bump -n foo` updates the `latestVersion` field of the versions.yaml file for the given package to the highest available version in `versions`.