### PR TITLE
fix: copy test files to new version

### DIFF
--- a/src/commands/package/index.ts
+++ b/src/commands/package/index.ts
@@ -5,6 +5,7 @@ import {SemVer} from 'semver';
 import {getArtifactPackage, getArtifactPackageVersion} from '../../datasources/artifacthub/index.js';
 import {getLatestRelease} from '../../datasources/github-release/index.js';
 import {
+  copyTestDirectory,
   copyUnmanagedFiles,
   createNewManifestVersion,
   getMaxVersion,
@@ -133,6 +134,7 @@ export default class Package extends Command {
         this.log('will create new version');
         await createNewManifestVersion(packagePaths, packageManifest, newAppVersion);
         await copyUnmanagedFiles(packagePaths, currentAppVersion, newAppVersion);
+        await copyTestDirectory(packagePaths, currentAppVersion, newAppVersion);
         this.log('latest version created');
       }
     }

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -6,7 +6,7 @@ import * as YAML from 'yaml';
 import {getPackageVersions} from './package.js';
 import {ManifestYaml, PackagePaths, PackageVersionPaths} from './paths.js';
 import {ArtifactHubPackage, PackageManifest} from './types/types.js';
-import {createDir, getFilesIn, parseYaml, read, write} from './utils/io.js';
+import {createDir, exists, getFilesIn, parseYaml, read, write} from './utils/io.js';
 
 export async function createNewManifestVersion(
   packagePaths: PackagePaths,
@@ -25,6 +25,19 @@ export async function copyUnmanagedFiles(pkg: PackagePaths, oldVersion: SemVer, 
       .filter(file => file !== 'package.yaml')
       .map(async file => await copyFile(join(oldVersionDir.dirName(), file), join(newVersionDir.dirName(), file))),
   );
+}
+
+export async function copyTestDirectory(pkg: PackagePaths, oldVersion: SemVer, newVersion: SemVer) {
+  const oldVersionDir = pkg.version(oldVersion.raw);
+  const newVersionDir = pkg.version(newVersion.raw);
+  if (await exists(oldVersionDir.testDir())) {
+    await createDir(newVersionDir.testDir());
+    await Promise.all(
+      (await getFilesIn(oldVersionDir.testDir())).map(
+        async file => await copyFile(join(oldVersionDir.testDir(), file), join(newVersionDir.testDir(), file)),
+      ),
+    );
+  }
 }
 
 async function writePackageManifestFile(paths: PackageVersionPaths, packageManifest: PackageManifest) {

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -5,7 +5,8 @@ type DirName = {readonly dirName: StringSupplier};
 type IndexYaml = {readonly indexYaml: StringSupplier};
 export type VersionsYaml = {readonly versionsYaml: StringSupplier};
 export type ManifestYaml = {readonly packageYaml: StringSupplier};
-export type PackageVersionPaths = DirName & ManifestYaml;
+export type TestDir = {readonly testDir: StringSupplier};
+export type PackageVersionPaths = DirName & ManifestYaml & TestDir;
 type WithPackageVersion = {readonly version: (version: string) => PackageVersionPaths};
 export type PackagePaths = DirName & ManifestYaml & VersionsYaml & WithPackageVersion;
 type WithPackage = {readonly package: (name: string) => PackagePaths};
@@ -21,6 +22,7 @@ export function packagePaths(base: string): Paths {
       version: (version: string) => ({
         dirName: () => path.join(base, name, version),
         packageYaml: () => path.join(base, name, version, 'package.yaml'),
+        testDir: () => path.join(base, name, version, '.test'),
       }),
       versionsYaml: () => path.join(base, name, 'versions.yaml'),
     }),

--- a/src/utils/io.ts
+++ b/src/utils/io.ts
@@ -26,3 +26,12 @@ export async function getFilesIn(path: string): Promise<string[]> {
   const allFiles = await fs.readdir(path, {withFileTypes: true});
   return allFiles.filter(it => !it.isDirectory()).map(it => it.name);
 }
+
+export async function exists(path: string): Promise<boolean> {
+  try {
+    await fs.access(path, fs.constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
closes #273 – this should fix a few of the currently failing updates (kube stack, quickwit at least)